### PR TITLE
fix #3 delete pre-cmd/exec hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,24 @@
 # Changelog
 
+## [3.1] - 2019-08-18
+### 🐞 Fixed
+- Fixed issue when Zsh did not initialize if host used `add-zsh-hook` to
+  customize prompts.
+
 ## [3.0] - 2019-07-07
-### ➕ Added 
-- 🔁 Now package is named `zsh-jupyter-kernel` for specificity 
+### ➕ Added
+- 🔁 Now package is named `zsh-jupyter-kernel` for specificity
   and released at https://pypi.org/project/zsh-jupyter-kernel/
 
 ## [2.1-2.3] - 2019-06-30
-
 ### ➕ Added
 - ⏹ Kernel interruption
 
 ## [2.0] - 2019-06-29
-
 ### ➕ Added
 - 📝 Multiline support
 - 🚀 This baby is on PyPi now: https://pypi.org/project/zsh-kernel/
 
 ## [1.0] - 2019-06-25
-
 ### Added
 - Required basic kernel functionality for singe line Z shell commands.
-

--- a/src/zsh_jupyter_kernel/config.py
+++ b/src/zsh_jupyter_kernel/config.py
@@ -16,7 +16,7 @@ config : Dict[str, Any] = {}
 config.update({
     'name': 'zsh-jupyter-kernel',
     'module': 'zsh_jupyter_kernel',
-    'version': '3.0',
+    'version': '3.1',
     'description': 'Z shell kernel for Jupyter',
     'author': 'Dan Oak',
     'author_email': 'danylo.dubinin@gmail.com',
@@ -101,6 +101,24 @@ config.update({
         'timeout': 5,
         'logfile': join(config['log_dir'], 'pexpect.log'),
     },
+    'zsh': {
+        'init_cmds': [
+            "TERM=dumb",
+
+            "autoload -Uz add-zsh-hook",
+            "add-zsh-hook -D precmd \*",
+            "add-zsh-hook -D preexec \*",
+                # [zsh-hooks]
+
+            "precmd() {}",
+            "preexec() {}",
+                # [zsh-functions]
+        ],
+        'config_cmds': [
+            "unset zle_bracketed_paste", # [zsh-bracketed-paste]
+            "zle_highlight=(none)", # https://linux.die.net/man/1/zshzle
+        ],
+    },
     'kernel': {
         'spec': { # [kernel-specs]
             "argv": [
@@ -155,6 +173,14 @@ if __name__ == '__main__':
 # [codecs]: https://docs.python.org/3/library/codecs.html
 # [logging]: https://docs.python-guide.org/writing/logging/
 # [zsh-options]: https://linux.die.net/man/1/zshoptions
+# [zsh-functions]: http://zsh.sourceforge.net/Doc/Release/Functions.html
+# [zsh-bracketed-paste]: https://archive.zhimingwang.org/blog/2015-09-21-zsh-51-and-bracketed-paste.html
+#
+# [zsh-hooks]: http://zsh.sourceforge.net/Doc/Release/User-Contributions.html
+#   - Section "Manipulating Hook Functions"
+#   Different plugins (e.g. oh-my-zsh with custom themes) use
+#   `precmd`/`preexec` hooks to set prompts. `add-zsh-hook -D <hook> <pattern>`
+#   allows to delete all assosiated functions from a hook.
 #
 # [interrupt]: https://jupyter-client.readthedocs.io/en/latest/messaging.html#kernel-interrupt
 # Interrupt by message does not work now but works by signal. This is

--- a/src/zsh_jupyter_kernel/kernel.py
+++ b/src/zsh_jupyter_kernel/kernel.py
@@ -50,17 +50,15 @@ class ZshKernel (Kernel):
 
     def _init_zsh_(self):
         init_cmds = [
-            "TERM=dumb",
-            "precmd() {}", # [zsh-functions]
+            *config['zsh']['init_cmds'],
             *map(lambda kv: "{}='{}'".format(*kv), self.prompts.items()),
         ]
         self.child.sendline("; ".join(init_cmds))
         self.child.expect_exact(self.prompts['PS1'])
-        init_cmds = [
-            "unset zle_bracketed_paste", # [zsh-bracketed-paste]
-            "zle_highlight=(none)", # https://linux.die.net/man/1/zshzle
+        config_cmds = [
+            *config['zsh']['config_cmds'],
         ]
-        self.child.sendline("; ".join(init_cmds))
+        self.child.sendline("; ".join(config_cmds))
         self.child.expect_exact(self.prompts['PS1'])
 
     def __init__(self, **kwargs):
@@ -278,5 +276,3 @@ class ZshKernel (Kernel):
 # [zsh-prompts]: https://jlk.fjfi.cvut.cz/arch/manpages/man/zshparam.1#PARAMETERS_USED_BY_THE_SHELL
 # [1]: # https://pexpect.readthedocs.io/en/stable/api/pexpect.html#pexpect.spawn.expect
 # [traceback]: https://docs.python.org/3/library/traceback.html#traceback.extract_tb
-# [zsh-functions]: http://zsh.sourceforge.net/Doc/Release/Functions.html
-# [zsh-bracketed-paste]: https://archive.zhimingwang.org/blog/2015-09-21-zsh-51-and-bracketed-paste.html


### PR DESCRIPTION
As discovered in #3 different plugins (e.g. oh-my-zsh with custom themes) use `precmd`/`preexec` hooks to set prompts. `add-zsh-hook -D <hook> <pattern>` allows to delete all assosiated functions from a hook.